### PR TITLE
Feat: 차량 전체 목록 및 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/car/controller/CarController.java
+++ b/src/main/java/com/erp/domain/car/controller/CarController.java
@@ -2,6 +2,7 @@ package com.erp.domain.car.controller;
 
 import com.erp.domain.car.dto.request.CarCreateRequest;
 import com.erp.domain.car.dto.request.CarUpdateRequest;
+import com.erp.domain.car.dto.response.CarDetailResponse;
 import com.erp.domain.car.dto.response.CarListResponse;
 import com.erp.domain.car.service.CarService;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,12 @@ public class CarController {
             @PageableDefault(size = 20, sort = "id") Pageable pageable
     ) {
         return ResponseEntity.ok(carService.getCarList(pageable));
+    }
+
+    /* 차량 기본 정보 조회(상세조회) */
+    @GetMapping("/{carId}")
+    public ResponseEntity<CarDetailResponse> getCarDetail(@PathVariable Long carId) {
+        return ResponseEntity.ok(carService.getCarDetail(carId));
     }
 
 }

--- a/src/main/java/com/erp/domain/car/controller/CarController.java
+++ b/src/main/java/com/erp/domain/car/controller/CarController.java
@@ -2,8 +2,12 @@ package com.erp.domain.car.controller;
 
 import com.erp.domain.car.dto.request.CarCreateRequest;
 import com.erp.domain.car.dto.request.CarUpdateRequest;
+import com.erp.domain.car.dto.response.CarListResponse;
 import com.erp.domain.car.service.CarService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,6 +37,14 @@ public class CarController {
     public ResponseEntity<Void> deleteCar(@PathVariable Long carId) {
         carService.deleteCar(carId);
         return ResponseEntity.noContent().build();
+    }
+
+    /* 전체 차량 목록 조회 */
+    @GetMapping
+    public ResponseEntity<Page<CarListResponse>> getCarList(
+            @PageableDefault(size = 20, sort = "id") Pageable pageable
+    ) {
+        return ResponseEntity.ok(carService.getCarList(pageable));
     }
 
 }

--- a/src/main/java/com/erp/domain/car/dto/response/CarDetailResponse.java
+++ b/src/main/java/com/erp/domain/car/dto/response/CarDetailResponse.java
@@ -1,0 +1,31 @@
+package com.erp.domain.car.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record CarDetailResponse(
+
+        Long carId,
+        String vehicleIdNumber,
+        String model,
+        Long price,
+        String brand,
+        Integer year,
+        Integer ageLimit,
+        String fuelType,
+        String image,
+        Long branchId,
+        String carNumber,
+        Long mileage,
+        LocalDate maintenanceDate,
+        String insuranceName,
+        String status,
+        Long purchasePrice,
+        Long modelPrice,
+        Integer seater,
+        String color
+
+) {
+}

--- a/src/main/java/com/erp/domain/car/dto/response/CarListResponse.java
+++ b/src/main/java/com/erp/domain/car/dto/response/CarListResponse.java
@@ -1,0 +1,23 @@
+package com.erp.domain.car.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CarListResponse (
+
+    Long carId,
+    String vehicleIdNumber,
+    String image,
+    String model,
+    Long branchId,
+    String branchName,
+    String carNumber,
+    Integer ageLimit,
+    Long mileage,
+    String status,
+    String fuelType,
+    Integer seater,
+    String color
+
+) {
+}

--- a/src/main/java/com/erp/domain/car/service/CarService.java
+++ b/src/main/java/com/erp/domain/car/service/CarService.java
@@ -4,12 +4,17 @@ import com.erp.domain.branch.entity.Branch;
 import com.erp.domain.branch.repository.BranchRepository;
 import com.erp.domain.car.dto.request.CarCreateRequest;
 import com.erp.domain.car.dto.request.CarUpdateRequest;
+import com.erp.domain.car.dto.response.CarListResponse;
 import com.erp.domain.car.entity.Car;
 import com.erp.domain.car.repository.CarRepository;
 import com.erp.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -135,5 +140,28 @@ public class CarService {
                 .orElseThrow(() -> new CustomException(404, "해당 차량이 존재하지 않습니다."));
 
         carRepository.delete(car);
+    }
+
+    /* 전체 차량 목록 조회 */
+    public Page<CarListResponse> getCarList(Pageable pageable) {
+        return carRepository.findAll(pageable)
+                .map(car -> CarListResponse.builder()
+                        .carId(car.getId())
+                        .vehicleIdNumber(car.getVehicleIdNumber())
+                        .image(car.getImage())
+                        .model(car.getModel())
+                        .branchId(Optional.ofNullable(car.getBranch())
+                                .map(Branch::getId).orElse(null))
+                        .branchName(Optional.ofNullable(car.getBranch())
+                                .map(Branch::getName).orElse(null))
+                        .carNumber(car.getCarNumber())
+                        .ageLimit(car.getAgeLimit())
+                        .mileage(car.getMileage())
+                        .status(car.getStatus().name())
+                        .fuelType(car.getFuelType().name())
+                        .seater(car.getSeater())
+                        .color(car.getColor().name())
+                        .build());
+
     }
 }

--- a/src/main/java/com/erp/domain/car/service/CarService.java
+++ b/src/main/java/com/erp/domain/car/service/CarService.java
@@ -4,6 +4,7 @@ import com.erp.domain.branch.entity.Branch;
 import com.erp.domain.branch.repository.BranchRepository;
 import com.erp.domain.car.dto.request.CarCreateRequest;
 import com.erp.domain.car.dto.request.CarUpdateRequest;
+import com.erp.domain.car.dto.response.CarDetailResponse;
 import com.erp.domain.car.dto.response.CarListResponse;
 import com.erp.domain.car.entity.Car;
 import com.erp.domain.car.repository.CarRepository;
@@ -162,6 +163,38 @@ public class CarService {
                         .seater(car.getSeater())
                         .color(car.getColor().name())
                         .build());
+
+    }
+
+    /* 차량 기본 정보 조회(상세조회) */
+    public CarDetailResponse getCarDetail(Long carId) {
+
+        Car car = carRepository.findById(carId)
+                .orElseThrow(() -> new CustomException(404, "해당 차량이 존재하지 않습니다."));
+
+        Long branchId = (car.getBranch() != null) ? car.getBranch().getId() : null;
+
+        return CarDetailResponse.builder()
+                .carId(car.getId())
+                .vehicleIdNumber(car.getVehicleIdNumber())
+                .model(car.getModel())
+                .price(car.getPrice())
+                .brand(car.getBrand())
+                .year(car.getYear())
+                .ageLimit(car.getAgeLimit())
+                .fuelType(car.getFuelType().name())
+                .image(car.getImage())
+                .branchId(branchId)
+                .carNumber(car.getCarNumber())
+                .mileage(car.getMileage())
+                .maintenanceDate(car.getMaintenanceDate())
+                .insuranceName(car.getInsuranceName())
+                .status(car.getStatus().name())
+                .purchasePrice(car.getPurchasePrice())
+                .modelPrice(car.getModelPrice())
+                .seater(car.getSeater())
+                .color(car.getColor().name())
+                .build();
 
     }
 }


### PR DESCRIPTION
## 작업 내용
- 차량 전체 목록 조회(페이징 적용) 및 상세 조회 기능 구현
- 차량 목록/상세 조회 목적에 따라 Response DTO를 분리하여 구성(CarListResponse, CarDetailResponse)

## 부연설명
- 페이지 사이즈에 대한 별도 명세가 없어 20으로 임의 설정했습니다.

## 관련 이슈
-  #16
