### PR TITLE
Feat: 차량 대여 이력 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/rent/controller/RentManagerController.java
+++ b/src/main/java/com/erp/domain/rent/controller/RentManagerController.java
@@ -1,0 +1,29 @@
+package com.erp.domain.rent.controller;
+
+import com.erp.domain.rent.dto.response.RentHistoryResponse;
+import com.erp.domain.rent.service.RentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/manager/vehicles")
+@RequiredArgsConstructor
+public class RentManagerController {
+
+    private final RentService rentService;
+
+    /* 차량 대여 이력 조회 */
+    @GetMapping("/rent/{carId}")
+    public Page<RentHistoryResponse> getRentHistory(
+            @PathVariable Long carId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return rentService.getRentHistory(carId, pageable);
+    }
+}

--- a/src/main/java/com/erp/domain/rent/dto/response/RentHistoryResponse.java
+++ b/src/main/java/com/erp/domain/rent/dto/response/RentHistoryResponse.java
@@ -1,0 +1,15 @@
+package com.erp.domain.rent.dto.response;
+
+import java.time.LocalDateTime;
+
+public record RentHistoryResponse(
+
+        Long rentId,
+        String clientName,
+        String clientPhone,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+
+) {
+}
+

--- a/src/main/java/com/erp/domain/rent/repository/RentRepository.java
+++ b/src/main/java/com/erp/domain/rent/repository/RentRepository.java
@@ -1,6 +1,8 @@
 package com.erp.domain.rent.repository;
 
 import com.erp.domain.rent.entity.Rent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +19,18 @@ public interface RentRepository extends JpaRepository<Rent, Long> {
 
     @Query("SELECT r FROM Rent r WHERE r.client.id = :id")
     List<Rent> findRentHistoryByClient(@Param("id") Long clientId);
+
+    /* 차량 대여 이력 조회 */
+    @Query("""
+            SELECT r
+            FROM Rent r
+            JOIN FETCH r.client c
+            WHERE r.car.id = :carId
+            AND r.endRentDateTime < :now
+            ORDER BY r.startRentDateTime DESC
+    """)
+    Page<Rent> findRentHistoryByCarId(
+            @Param("carId") Long carId,
+            @Param("now") LocalDateTime now,
+            Pageable pageable);
 }

--- a/src/main/java/com/erp/domain/rent/service/RentService.java
+++ b/src/main/java/com/erp/domain/rent/service/RentService.java
@@ -1,0 +1,33 @@
+package com.erp.domain.rent.service;
+
+import com.erp.domain.rent.dto.response.RentHistoryResponse;
+import com.erp.domain.rent.entity.Rent;
+import com.erp.domain.rent.repository.RentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RentService {
+
+    private final RentRepository rentRepository;
+
+    public Page<RentHistoryResponse> getRentHistory(Long carId, Pageable pageable) {
+
+        Page<Rent> rents = rentRepository.findRentHistoryByCarId(carId, LocalDateTime.now(), pageable);
+
+        return rents.map(rent -> new RentHistoryResponse(
+                rent.getId(),
+                rent.getClient().getName(),
+                rent.getClient().getPhoneNumber(),
+                rent.getStartRentDateTime(),
+                rent.getEndRentDateTime()
+        ));
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 관리자용 차량 대여 이력 조회 API 구현
- 대여 이력 응답 DTO 생성(RentHistoryResponse)

## 부연설명
- 로직은 Rent 도메인에 구현하고, URL만 차량 관리(vehicles)로 매핑했습니다.
- 조회 조건 : 현재 시간 기준 반납이 완료된 과거 데이터만 조회됩니다.

## 관련 이슈
-  #16
