### PR TITLE
Feat: 차량 정비 이력 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/maintenance/controller/MaintenanceManagerController.java
+++ b/src/main/java/com/erp/domain/maintenance/controller/MaintenanceManagerController.java
@@ -1,0 +1,29 @@
+package com.erp.domain.maintenance.controller;
+
+import com.erp.domain.maintenance.dto.response.MaintenanceHistoryResponse;
+import com.erp.domain.maintenance.service.MaintenanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/manager/vehicles")
+public class MaintenanceManagerController {
+
+    private final MaintenanceService maintenanceService;
+
+    /* 차량 정비 이력 조회 */
+    @GetMapping("/maint/{carId}")
+    public Page<MaintenanceHistoryResponse> getMaintenanceHistory(
+            @PathVariable Long carId,
+            @PageableDefault Pageable pageable
+    ) {
+        return maintenanceService.getMaintenanceHistory(carId, pageable);
+    }
+}

--- a/src/main/java/com/erp/domain/maintenance/dto/response/MaintenanceHistoryResponse.java
+++ b/src/main/java/com/erp/domain/maintenance/dto/response/MaintenanceHistoryResponse.java
@@ -1,0 +1,20 @@
+package com.erp.domain.maintenance.dto.response;
+
+import com.erp.domain.maintenance.entity.MaintenanceStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MaintenanceHistoryResponse(
+
+        Long maintenanceId,
+        String title,
+        String detail,
+        LocalDate maintenanceDate,
+        Long cost,
+        Long employeeId,
+        String employeeName,
+        MaintenanceStatus status
+) {
+}

--- a/src/main/java/com/erp/domain/maintenance/repository/MaintenanceRepository.java
+++ b/src/main/java/com/erp/domain/maintenance/repository/MaintenanceRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+
 
 public interface MaintenanceRepository extends JpaRepository<Maintenance, Long> {
     @Query("""
@@ -35,5 +37,20 @@ public interface MaintenanceRepository extends JpaRepository<Maintenance, Long> 
                                          @Param("status") MaintenanceStatus status,
                                          @Param("keyword") String keyword,
                                          Pageable pageable);
+
+    /* 차량 정비 이력 조회 */
+    @Query("""
+            SELECT m
+            FROM Maintenance m
+            JOIN FETCH m.employee e
+            WHERE m.car.id = :cardId
+            AND m.maintenanceDate <= :now
+            ORDER BY m.maintenanceDate DESC
+    """)
+    Page<Maintenance> findMaintenanceHistory(
+            @Param("cardId") Long cardId,
+            @Param("now") LocalDate now,
+            Pageable pageable);
+
 }
 

--- a/src/main/java/com/erp/domain/maintenance/service/MaintenanceService.java
+++ b/src/main/java/com/erp/domain/maintenance/service/MaintenanceService.java
@@ -6,6 +6,7 @@ import com.erp.domain.employee.entity.Employee;
 import com.erp.domain.employee.repository.EmployeeRepository;
 import com.erp.domain.maintenance.dto.request.MaintenanceRequest;
 import com.erp.domain.maintenance.dto.response.MaintenanceDetailResponse;
+import com.erp.domain.maintenance.dto.response.MaintenanceHistoryResponse;
 import com.erp.domain.maintenance.dto.response.MaintenanceListResponse;
 import com.erp.domain.maintenance.entity.Maintenance;
 import com.erp.domain.maintenance.entity.MaintenanceStatus;
@@ -16,6 +17,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -112,6 +115,28 @@ public class MaintenanceService {
                 maintenance.getCost(),
                 maintenance.getStatus(),
                 maintenance.getDetail()
+        );
+    }
+
+    /* 차량 정비 이력 조회 */
+    public Page<MaintenanceHistoryResponse> getMaintenanceHistory(Long carId, Pageable pageable) {
+
+        Page<Maintenance> maintenanceList = maintenanceRepository.findMaintenanceHistory(
+                carId,
+                LocalDate.now(),
+                pageable
+        );
+
+        return maintenanceList.map(m -> MaintenanceHistoryResponse.builder()
+                .maintenanceId(m.getId())
+                .title(m.getTitle())
+                .detail(m.getDetail())
+                .maintenanceDate(m.getMaintenanceDate())
+                .cost(m.getCost())
+                .employeeId(m.getEmployee().getId())
+                .employeeName(m.getEmployeeName())
+                .status(m.getStatus())
+                .build()
         );
     }
 }


### PR DESCRIPTION
## 작업 내용
- 관리자용 차량 정비 이력 조회 API 구현
- 정비 이력 응답 DTO 생성(MaintenanceHistoryResponse)

## 부연설명
- 로직은 Maintenance 도메인에 구현하고, URL만 차량 관리(vehicles)로 매핑했습니다.
- 조회 조건 : 미래의 예약 건은 제외하고, 오늘 날짜 기준 과거 정비 이력만 조회됩니다.
- Repository에 JOIN FETCH를 적용하여 담당 직원(Employee) 정보 조회 시 발생하는 N+1 문제를 해결했습니다.

## 관련 이슈
-  #16
