### PR TITLE
Feat: 차량 상태별 수량 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/car/controller/CarController.java
+++ b/src/main/java/com/erp/domain/car/controller/CarController.java
@@ -5,6 +5,7 @@ import com.erp.domain.car.dto.request.CarSearchRequest;
 import com.erp.domain.car.dto.request.CarUpdateRequest;
 import com.erp.domain.car.dto.response.CarDetailResponse;
 import com.erp.domain.car.dto.response.CarListResponse;
+import com.erp.domain.car.dto.response.CarStatusCountResponse;
 import com.erp.domain.car.service.CarService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -38,6 +39,12 @@ public class CarController {
     public ResponseEntity<Void> deleteCar(@PathVariable Long carId) {
         carService.deleteCar(carId);
         return ResponseEntity.noContent().build();
+    }
+
+    /* 차량 상태별 수량 조회 */
+    @GetMapping("/status")
+    public CarStatusCountResponse getCarStatusCount() {
+        return carService.getCarStatusCount();
     }
 
     /* 전체 차량 목록 조회 + 조건 검색 통합 */

--- a/src/main/java/com/erp/domain/car/dto/response/CarStatusCountResponse.java
+++ b/src/main/java/com/erp/domain/car/dto/response/CarStatusCountResponse.java
@@ -1,0 +1,13 @@
+package com.erp.domain.car.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CarStatusCountResponse(
+
+        long total,
+        long driving,
+        long maintenance,
+        long waiting
+) {
+}

--- a/src/main/java/com/erp/domain/car/repository/CarRepository.java
+++ b/src/main/java/com/erp/domain/car/repository/CarRepository.java
@@ -1,5 +1,6 @@
 package com.erp.domain.car.repository;
 
+import com.erp.domain.car.dto.response.CarStatusCountResponse;
 import com.erp.domain.car.entity.Car;
 import com.erp.domain.car.entity.CarStatus;
 import com.erp.domain.car.entity.FuelType;
@@ -42,4 +43,16 @@ public interface CarRepository extends JpaRepository<Car, Long> {
             @Param("fuelType") FuelType fuelType,
             @Param("status") CarStatus status,
             Pageable pageable);
+
+    /* 차량 상태별 수량 조회 */
+    @Query("""
+        SELECT new com.erp.domain.car.dto.response.CarStatusCountResponse(
+            COUNT(c),
+            COUNT(CASE WHEN c.status = 'DRIVING' THEN 1 END),
+            COUNT(CASE WHEN c.status = 'MAINTENANCE' THEN 1 END),
+            COUNT(CASE WHEN c.status = 'WAITING' THEN 1 END)
+        )
+        FROM Car c
+    """)
+    CarStatusCountResponse countCarByStatus();
 }

--- a/src/main/java/com/erp/domain/car/service/CarService.java
+++ b/src/main/java/com/erp/domain/car/service/CarService.java
@@ -7,6 +7,7 @@ import com.erp.domain.car.dto.request.CarSearchRequest;
 import com.erp.domain.car.dto.request.CarUpdateRequest;
 import com.erp.domain.car.dto.response.CarDetailResponse;
 import com.erp.domain.car.dto.response.CarListResponse;
+import com.erp.domain.car.dto.response.CarStatusCountResponse;
 import com.erp.domain.car.entity.Car;
 import com.erp.domain.car.repository.CarRepository;
 import com.erp.global.exception.CustomException;
@@ -227,5 +228,10 @@ public class CarService {
                 .seater(car.getSeater())
                 .color(car.getColor().name())
                 .build());
+    }
+
+    /* 차량 상태별 수량 조회 */
+    public CarStatusCountResponse getCarStatusCount() {
+        return carRepository.countCarByStatus();
     }
 }


### PR DESCRIPTION
## 작업 내용
- 관리자용 차량 페이지 상단 대시보드 상태별 수량 조회 기능
- 차량 상태별 수량 응답 DTO 생성(CarStatusCountResponse)

## 부연설명
- 전체, 대여중, 정비중, 대기 차량 수량을 한 번에 조회하도록 구현

## 관련 이슈
-  #42 
