### PR TITLE
Feat: 기간별 대여 건수 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -34,4 +34,13 @@ public class StatisticsController {
     ) {
         return statisticsService.getDailyRentStats(startDate, endDate);
     }
+
+    /* 주간 대여 건수 조회 */
+    @GetMapping("/case/week")
+    public List<StatisticsResponse> getWeeklyCaseStats(
+            @RequestParam String startDate,
+            @RequestParam String endDate
+    ) {
+        return statisticsService.getWeeklyRentStats(startDate, endDate);
+    }
 }

--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -5,6 +5,7 @@ import com.erp.domain.statistics.service.StatisticsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,7 +19,10 @@ public class StatisticsController {
 
     /* 월간 대여 건수 조회 */
     @GetMapping("/case/month")
-    public List<StatisticsResponse> getMonthlyCaseStats() {
-        return statisticsService.getMonthlyRentStats();
+    public List<StatisticsResponse> getMonthlyCaseStats(
+            @RequestParam String startMonth,
+            @RequestParam String endMonth
+    ) {
+        return statisticsService.getMonthlyRentStats(startMonth, endMonth);
     }
 }

--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -25,4 +25,13 @@ public class StatisticsController {
     ) {
         return statisticsService.getMonthlyRentStats(startMonth, endMonth);
     }
+
+    /* 일간 대여 건수 조회 */
+    @GetMapping("/case/day")
+    public List<StatisticsResponse> getDailyCaseStats(
+            @RequestParam String startDate, // 예: 2026-01-01
+            @RequestParam String endDate    // 예: 2026-01-31
+    ) {
+        return statisticsService.getDailyRentStats(startDate, endDate);
+    }
 }

--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -1,0 +1,24 @@
+package com.erp.domain.statistics.controller;
+
+import com.erp.domain.statistics.dto.StatisticsResponse;
+import com.erp.domain.statistics.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/manager/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    /* 월간 대여 건수 조회 */
+    @GetMapping("/case/month")
+    public List<StatisticsResponse> getMonthlyCaseStats() {
+        return statisticsService.getMonthlyRentStats();
+    }
+}

--- a/src/main/java/com/erp/domain/statistics/dto/StatisticsResponse.java
+++ b/src/main/java/com/erp/domain/statistics/dto/StatisticsResponse.java
@@ -1,0 +1,7 @@
+package com.erp.domain.statistics.dto;
+
+public record StatisticsResponse(
+        String label,
+        Long count
+) {
+}

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsProjection.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsProjection.java
@@ -1,0 +1,6 @@
+package com.erp.domain.statistics.repository;
+
+public interface StatisticsProjection {
+    String getLabel();
+    Long getCount();
+}

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -49,4 +49,24 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
+
+    /* 주간 대여 건수 조회 */
+    @Query(
+            value = """
+            SELECT
+                DATE_FORMAT(r.start_rent_date_time, '%Y-%u') AS label,
+                COUNT(r.id) AS count
+            FROM rent r
+            WHERE r.start_rent_date_time BETWEEN :startDate AND :endDate
+              AND r.end_rent_date_time IS NOT NULL
+            GROUP BY label
+            ORDER BY label ASC
+        """,
+            nativeQuery = true
+    )
+    List<StatisticsProjection> findWeeklyRentCount(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -12,13 +12,14 @@ import java.util.List;
 @Repository
 public interface StatisticsRepository extends JpaRepository<Rent, Long> {
 
+    /* 월간 대여 건수 조회 */
     @Query(
             value = """
             SELECT
                 DATE_FORMAT(r.start_rent_date_time, '%Y-%m') AS label,
                 COUNT(r.id) AS count
             FROM rent r
-            WHERE r.start_rent_date_time >= :startDate
+            WHERE r.start_rent_date_time >= :startDate AND :endDate
               AND r.end_rent_date_time IS NOT NULL
             GROUP BY label
             ORDER BY label ASC
@@ -26,6 +27,25 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             nativeQuery = true
     )
     List<StatisticsProjection> findMonthlyRentCount(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
+    /* 일간 대여 건수 조회 */
+    @Query(
+            value = """
+            SELECT
+                DATE_FORMAT(r.start_rent_date_time, '%Y-%m-%d') AS label,
+                COUNT(r.id) AS count
+            FROM rent r
+            WHERE r.start_rent_date_time BETWEEN :startDate AND :endDate
+              AND r.end_rent_date_time IS NOT NULL
+            GROUP BY label
+            ORDER BY label ASC
+        """,
+            nativeQuery = true
+    )
+    List<StatisticsProjection> findDailyRentCount(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -25,5 +25,5 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
         """,
             nativeQuery = true
     )
-    List<Object[]> findMonthlyRentCount(@Param("startDate") LocalDateTime startDate);
+    List<StatisticsProjection> findMonthlyRentCount(@Param("startDate") LocalDateTime startDate);
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -1,0 +1,29 @@
+package com.erp.domain.statistics.repository;
+
+import com.erp.domain.rent.entity.Rent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface StatisticsRepository extends JpaRepository<Rent, Long> {
+
+    @Query(
+            value = """
+            SELECT
+                DATE_FORMAT(r.start_rent_date_time, '%Y-%m') AS label,
+                COUNT(r.id) AS count
+            FROM rent r
+            WHERE r.start_rent_date_time >= :startDate
+              AND r.end_rent_date_time IS NOT NULL
+            GROUP BY label
+            ORDER BY label ASC
+        """,
+            nativeQuery = true
+    )
+    List<Object[]> findMonthlyRentCount(@Param("startDate") LocalDateTime startDate);
+}

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -25,5 +25,8 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
         """,
             nativeQuery = true
     )
-    List<StatisticsProjection> findMonthlyRentCount(@Param("startDate") LocalDateTime startDate);
+    List<StatisticsProjection> findMonthlyRentCount(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 }

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 
 @Service
@@ -17,13 +18,15 @@ public class StatisticsService {
     private final StatisticsRepository rentStatisticsRepository;
 
     /* 월간 대여 건수 통계(최근 1년) */
-    public List<StatisticsResponse> getMonthlyRentStats() {
-        LocalDateTime oneYearAgo = LocalDateTime.now()
-                .minusYears(1)
-                .withDayOfMonth(1)
-                .withHour(0).withMinute(0).withSecond(0);
+    public List<StatisticsResponse> getMonthlyRentStats(String startMonth, String endMonth) {
 
-        return rentStatisticsRepository.findMonthlyRentCount(oneYearAgo)
+        YearMonth start = YearMonth.parse(startMonth);
+        LocalDateTime startDate = start.atDay(1).atStartOfDay();
+
+        YearMonth end = YearMonth.parse(endMonth);
+        LocalDateTime endDate = end.atEndOfMonth().atTime(23, 59, 59);
+
+        return rentStatisticsRepository.findMonthlyRentCount(startDate, endDate)
                 .stream()
                 .map(row -> new StatisticsResponse(
                         row.getLabel(),

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -17,7 +18,7 @@ public class StatisticsService {
 
     private final StatisticsRepository rentStatisticsRepository;
 
-    /* 월간 대여 건수 통계(최근 1년) */
+    /* 월간 대여 건수 통계 */
     public List<StatisticsResponse> getMonthlyRentStats(String startMonth, String endMonth) {
 
         YearMonth start = YearMonth.parse(startMonth);
@@ -35,4 +36,22 @@ public class StatisticsService {
                 .toList();
 
     }
+
+    /* 일간 대여 건수 통계 */
+    public List<StatisticsResponse> getDailyRentStats(String startDateStr, String endDateStr) {
+
+        LocalDate start = LocalDate.parse(startDateStr);
+        LocalDateTime startDate = start.atStartOfDay();
+
+        LocalDate end = LocalDate.parse(endDateStr);
+        LocalDateTime endDate = end.atTime(23, 59, 59);
+
+        return rentStatisticsRepository.findDailyRentCount(startDate, endDate)
+                .stream()
+                .map(row -> new StatisticsResponse(
+                        row.getLabel(),
+                        row.getCount()))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -26,8 +26,8 @@ public class StatisticsService {
         return rentStatisticsRepository.findMonthlyRentCount(oneYearAgo)
                 .stream()
                 .map(row -> new StatisticsResponse(
-                        (String) row[0],
-                        ((Number) row[1]).longValue()
+                        row.getLabel(),
+                        row.getCount()
                 ))
                 .toList();
 

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class StatisticsService {
 
-    private final StatisticsRepository rentStatisticsRepository;
+    private final StatisticsRepository statisticsRepository;
 
     /* 월간 대여 건수 통계 */
     public List<StatisticsResponse> getMonthlyRentStats(String startMonth, String endMonth) {
@@ -27,7 +27,7 @@ public class StatisticsService {
         YearMonth end = YearMonth.parse(endMonth);
         LocalDateTime endDate = end.atEndOfMonth().atTime(23, 59, 59);
 
-        return rentStatisticsRepository.findMonthlyRentCount(startDate, endDate)
+        return statisticsRepository.findMonthlyRentCount(startDate, endDate)
                 .stream()
                 .map(row -> new StatisticsResponse(
                         row.getLabel(),
@@ -46,7 +46,24 @@ public class StatisticsService {
         LocalDate end = LocalDate.parse(endDateStr);
         LocalDateTime endDate = end.atTime(23, 59, 59);
 
-        return rentStatisticsRepository.findDailyRentCount(startDate, endDate)
+        return statisticsRepository.findDailyRentCount(startDate, endDate)
+                .stream()
+                .map(row -> new StatisticsResponse(
+                        row.getLabel(),
+                        row.getCount()))
+                .toList();
+    }
+
+    /* 주간 대여 건수 통계 */
+    public List<StatisticsResponse> getWeeklyRentStats(String startDateStr, String endDateStr) {
+
+        LocalDate start = LocalDate.parse(startDateStr);
+        LocalDateTime startDate = start.atStartOfDay();
+
+        LocalDate end = LocalDate.parse(endDateStr);
+        LocalDateTime endDate = end.atTime(23, 59, 59);
+
+        return statisticsRepository.findWeeklyRentCount(startDate, endDate)
                 .stream()
                 .map(row -> new StatisticsResponse(
                         row.getLabel(),

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -1,0 +1,35 @@
+package com.erp.domain.statistics.service;
+
+import com.erp.domain.statistics.dto.StatisticsResponse;
+import com.erp.domain.statistics.repository.StatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsService {
+
+    private final StatisticsRepository rentStatisticsRepository;
+
+    /* 월간 대여 건수 통계(최근 1년) */
+    public List<StatisticsResponse> getMonthlyRentStats() {
+        LocalDateTime oneYearAgo = LocalDateTime.now()
+                .minusYears(1)
+                .withDayOfMonth(1)
+                .withHour(0).withMinute(0).withSecond(0);
+
+        return rentStatisticsRepository.findMonthlyRentCount(oneYearAgo)
+                .stream()
+                .map(row -> new StatisticsResponse(
+                        (String) row[0],
+                        ((Number) row[1]).longValue()
+                ))
+                .toList();
+
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 월간(Monthly) 대여 건수 조회
- 주간(Weekly) 대여 건수 조회
- 일간(Daily) 대여 건수 조회

## 부연설명
- Native Query 활용 : JPQL만으로는 구현이 복잡한 날짜 포맷팅과 동적 그룹핑을 처리하기 위해 Native Qyuery를 사용했습니다.
- JPA Projection : 기존 List<Object[]> 반환 방식의 불안정한 형변환 문제를 해결하고자 Interface기반의 Projection을 적용하였습니다.

## 관련 이슈
-  #47 
