### PR TITLE
Feat: 쿠폰 생성,발급,조회 기능 구현

### DIFF
--- a/src/main/java/com/erp/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/erp/domain/coupon/controller/CouponController.java
@@ -2,13 +2,13 @@ package com.erp.domain.coupon.controller;
 
 import com.erp.domain.coupon.dto.request.CouponIssueRequest;
 import com.erp.domain.coupon.dto.request.CouponSaveRequest;
+import com.erp.domain.coupon.dto.response.ClientCouponResponse;
 import com.erp.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,7 +26,13 @@ public class CouponController {
     /* [사용자] 쿠폰 발급 */
     @PostMapping("/issue")
     public Long issueCoupon(@RequestBody @Valid CouponIssueRequest request) {
-        return couponService.issueCoupon(request.clientId(), request.couponCode());
+        return couponService.issueCoupon(request.clientId(), request.code());
+    }
+
+    /* 내 쿠폰 목록 조회 */
+    @GetMapping("/my/{clientId}")
+    public List<ClientCouponResponse> getMyCoupons(@PathVariable Long clientId) {
+        return couponService.getMyCoupons(clientId);
     }
 
 }

--- a/src/main/java/com/erp/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/erp/domain/coupon/controller/CouponController.java
@@ -1,5 +1,6 @@
 package com.erp.domain.coupon.controller;
 
+import com.erp.domain.coupon.dto.request.CouponIssueRequest;
 import com.erp.domain.coupon.dto.request.CouponSaveRequest;
 import com.erp.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
@@ -20,6 +21,12 @@ public class CouponController {
     @PostMapping
     public Long createCoupon(@RequestBody @Valid CouponSaveRequest request) {
         return couponService.createCoupon(request);
+    }
+
+    /* [사용자] 쿠폰 발급 */
+    @PostMapping("/issue")
+    public Long issueCoupon(@RequestBody @Valid CouponIssueRequest request) {
+        return couponService.issueCoupon(request.clientId(), request.couponCode());
     }
 
 }

--- a/src/main/java/com/erp/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/erp/domain/coupon/controller/CouponController.java
@@ -1,0 +1,25 @@
+package com.erp.domain.coupon.controller;
+
+import com.erp.domain.coupon.dto.request.CouponSaveRequest;
+import com.erp.domain.coupon.service.CouponService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    /* [관리자] 쿠폰 생성 API */
+    @PostMapping
+    public Long createCoupon(@RequestBody @Valid CouponSaveRequest request) {
+        return couponService.createCoupon(request);
+    }
+
+}

--- a/src/main/java/com/erp/domain/coupon/dto/request/CouponIssueRequest.java
+++ b/src/main/java/com/erp/domain/coupon/dto/request/CouponIssueRequest.java
@@ -3,6 +3,6 @@ package com.erp.domain.coupon.dto.request;
 public record CouponIssueRequest(
 
     Long clientId,
-    String couponCode
+    String code
 ) {
 }

--- a/src/main/java/com/erp/domain/coupon/dto/request/CouponIssueRequest.java
+++ b/src/main/java/com/erp/domain/coupon/dto/request/CouponIssueRequest.java
@@ -1,0 +1,8 @@
+package com.erp.domain.coupon.dto.request;
+
+public record CouponIssueRequest(
+
+    Long clientId,
+    String couponCode
+) {
+}

--- a/src/main/java/com/erp/domain/coupon/dto/request/CouponSaveRequest.java
+++ b/src/main/java/com/erp/domain/coupon/dto/request/CouponSaveRequest.java
@@ -1,0 +1,29 @@
+package com.erp.domain.coupon.dto.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record CouponSaveRequest(
+
+        @NotBlank(message = "쿠폰명은 필수 입력 항목입니다.")
+        String couponName,
+
+        @NotBlank(message = "할인율은 필수 입력 항목입니다.")
+        @Min(value = 100, message = "할인율은 100원 이상이어야 합니다.")
+        Integer discount,
+
+        @NotNull(message = "유효기간은 필수 입력 항목입니다.")
+        @Future(message = "유효기간은 현재 날짜 이후여야 합니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate expDate,
+        String code,
+
+        @Min(value = 0, message = "최소 구매 금액은 1000원 이상이어야 합니다.")
+        Integer minPrice
+) {
+}

--- a/src/main/java/com/erp/domain/coupon/dto/request/CouponSaveRequest.java
+++ b/src/main/java/com/erp/domain/coupon/dto/request/CouponSaveRequest.java
@@ -13,8 +13,8 @@ public record CouponSaveRequest(
         @NotBlank(message = "쿠폰명은 필수 입력 항목입니다.")
         String couponName,
 
-        @NotNull(message = "할인율은 필수 입력 항목입니다.")
-        @Min(value = 100, message = "할인율은 100원 이상이어야 합니다.")
+        @NotNull(message = "할인금액은 필수 입력 항목입니다.")
+        @Min(value = 1000, message = "할인금액은 1000원 이상이어야 합니다.")
         Integer discount,
 
         @NotNull(message = "유효기간은 필수 입력 항목입니다.")
@@ -23,7 +23,7 @@ public record CouponSaveRequest(
         LocalDate expDate,
         String code,
 
-        @Min(value = 0, message = "최소 구매 금액은 1000원 이상이어야 합니다.")
+        @Min(value = 1000, message = "최소 구매 금액은 1000원 이상이어야 합니다.")
         Integer minPrice
 ) {
 }

--- a/src/main/java/com/erp/domain/coupon/dto/request/CouponSaveRequest.java
+++ b/src/main/java/com/erp/domain/coupon/dto/request/CouponSaveRequest.java
@@ -13,7 +13,7 @@ public record CouponSaveRequest(
         @NotBlank(message = "쿠폰명은 필수 입력 항목입니다.")
         String couponName,
 
-        @NotBlank(message = "할인율은 필수 입력 항목입니다.")
+        @NotNull(message = "할인율은 필수 입력 항목입니다.")
         @Min(value = 100, message = "할인율은 100원 이상이어야 합니다.")
         Integer discount,
 

--- a/src/main/java/com/erp/domain/coupon/dto/response/ClientCouponResponse.java
+++ b/src/main/java/com/erp/domain/coupon/dto/response/ClientCouponResponse.java
@@ -1,5 +1,7 @@
 package com.erp.domain.coupon.dto.response;
 
+import com.erp.domain.coupon.entity.CouponStatus;
+
 import java.time.LocalDate;
 
 public record ClientCouponResponse(
@@ -9,6 +11,6 @@ public record ClientCouponResponse(
         Integer discount,
         LocalDate expDate,
         String code,
-        String status
+        CouponStatus status
 ) {
 }

--- a/src/main/java/com/erp/domain/coupon/dto/response/ClientCouponResponse.java
+++ b/src/main/java/com/erp/domain/coupon/dto/response/ClientCouponResponse.java
@@ -1,0 +1,14 @@
+package com.erp.domain.coupon.dto.response;
+
+import java.time.LocalDate;
+
+public record ClientCouponResponse(
+
+        Long clientCouponId,
+        String couponName,
+        Integer discount,
+        LocalDate expDate,
+        String code,
+        String status
+) {
+}

--- a/src/main/java/com/erp/domain/coupon/entity/ClientCoupon.java
+++ b/src/main/java/com/erp/domain/coupon/entity/ClientCoupon.java
@@ -1,0 +1,38 @@
+package com.erp.domain.coupon.entity;
+
+import com.erp.common.entity.BaseTimeEntity;
+import com.erp.domain.client.entity.Client;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "client_coupon")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ClientCoupon extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id")
+    private Client client;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @Column(name = "is_used")
+    @Builder.Default
+    private boolean isUsed = false;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+}

--- a/src/main/java/com/erp/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/erp/domain/coupon/entity/Coupon.java
@@ -29,7 +29,10 @@ public class Coupon extends BaseTimeEntity {
     @Column(name = "exp_date", nullable = false)
     private LocalDate expDate;
 
-    @Column(name = "code")
+    @Column(name = "code", unique = true)
     private String code;
+
+    @Column(name = "min_price")
+    private Integer minPrice;
 }
 

--- a/src/main/java/com/erp/domain/coupon/entity/CouponStatus.java
+++ b/src/main/java/com/erp/domain/coupon/entity/CouponStatus.java
@@ -1,0 +1,7 @@
+package com.erp.domain.coupon.entity;
+
+public enum CouponStatus {
+    AVAILABLE,
+    USED,
+    EXPIRED
+}

--- a/src/main/java/com/erp/domain/coupon/repository/ClientCouponRepository.java
+++ b/src/main/java/com/erp/domain/coupon/repository/ClientCouponRepository.java
@@ -1,0 +1,12 @@
+package com.erp.domain.coupon.repository;
+
+import com.erp.domain.coupon.entity.ClientCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ClientCouponRepository extends JpaRepository<ClientCoupon, Long> {
+
+    /* 특정 유저(ClientId)가 가진 모든 쿠폰 조회 */
+    List<ClientCoupon> findByClientId(Long clientId);
+}

--- a/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
@@ -3,5 +3,10 @@ package com.erp.domain.coupon.repository;
 import com.erp.domain.coupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    /* 쿠폰 코드로 조회 */
+    Optional<Coupon> findByCode(String code);
 }

--- a/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     /* 쿠폰 코드로 조회 */
-    Optional<Coupon> findByCode(String couponCode);
+    Optional<Coupon> findAllByCode(String couponCode);
 }

--- a/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     /* 쿠폰 코드로 조회 */
-    Optional<Coupon> findByCode(String code);
+    Optional<Coupon> findByCode(String couponCode);
 }

--- a/src/main/java/com/erp/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/erp/domain/coupon/service/CouponService.java
@@ -3,8 +3,10 @@ package com.erp.domain.coupon.service;
 import com.erp.domain.client.entity.Client;
 import com.erp.domain.client.repository.ClientRepository;
 import com.erp.domain.coupon.dto.request.CouponSaveRequest;
+import com.erp.domain.coupon.dto.response.ClientCouponResponse;
 import com.erp.domain.coupon.entity.ClientCoupon;
 import com.erp.domain.coupon.entity.Coupon;
+import com.erp.domain.coupon.entity.CouponStatus;
 import com.erp.domain.coupon.repository.ClientCouponRepository;
 import com.erp.domain.coupon.repository.CouponRepository;
 import com.erp.global.exception.CustomException;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -33,8 +36,8 @@ public class CouponService {
         if (couponCode == null || couponCode.isBlank()) {
             couponCode = generateRandomCode();
         } else {
-            if (couponRepository.findByCode(couponCode).isPresent()) {
-                throw new CustomException(404, "이미 존재하는 쿠폰 코드입니다.");
+            if (couponRepository.findAllByCode(couponCode).isPresent()) {
+                throw new CustomException(400, "이미 존재하는 쿠폰 코드입니다.");
             }
         }
 
@@ -60,11 +63,11 @@ public class CouponService {
         Client client = clientRepository.findById(clientId)
                 .orElseThrow(() -> new CustomException(404, "존재하지 않는 회원입니다."));
 
-        Coupon coupon = couponRepository.findByCode(couponCode)
+        Coupon coupon = couponRepository.findAllByCode(couponCode)
                 .orElseThrow(() -> new CustomException(404, "유효하지 않은 쿠폰 코드입니다."));
 
         if (coupon.getExpDate().isBefore(LocalDate.now())) {
-            throw new CustomException(404, "만료된 쿠폰입니다.");
+            throw new CustomException(400, "만료된 쿠폰입니다.");
         }
 
         ClientCoupon clientCoupon = ClientCoupon.builder()
@@ -74,6 +77,32 @@ public class CouponService {
                 .build();
 
         return clientCouponRepository.save(clientCoupon).getId();
+    }
+
+    /* 내 쿠폰 목록 조회 */
+    public List<ClientCouponResponse> getMyCoupons(Long clientId) {
+
+        List<ClientCoupon> myCoupons = clientCouponRepository.findByClientId(clientId);
+
+        return myCoupons.stream().map(clientCoupon -> {
+
+            CouponStatus status = CouponStatus.AVAILABLE;
+
+            if (clientCoupon.isUsed()) {
+                status = CouponStatus.USED;
+            } else if (clientCoupon.getCoupon().getExpDate().isBefore(LocalDate.now())) {
+                status = CouponStatus.EXPIRED;
+            }
+
+            return new ClientCouponResponse(
+                    clientCoupon.getId(),
+                    clientCoupon.getCoupon().getCouponName(),
+                    clientCoupon.getCoupon().getDiscount(),
+                    clientCoupon.getCoupon().getExpDate(),
+                    clientCoupon.getCoupon().getCode(),
+                    status
+            );
+        }).toList();
     }
 
 }

--- a/src/main/java/com/erp/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/erp/domain/coupon/service/CouponService.java
@@ -27,6 +27,7 @@ public class CouponService {
     /* [관리자] 쿠폰 생성 */
     @Transactional
     public Long createCoupon(CouponSaveRequest requestDto) {
+
         String couponCode = requestDto.code();
 
         if (couponCode == null || couponCode.isBlank()) {
@@ -50,6 +51,29 @@ public class CouponService {
 
     private String generateRandomCode() {
         return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+    /* [사용자] 쿠폰 발급 */
+    @Transactional
+    public Long issueCoupon(Long clientId, String couponCode) {
+
+        Client client = clientRepository.findById(clientId)
+                .orElseThrow(() -> new CustomException(404, "존재하지 않는 회원입니다."));
+
+        Coupon coupon = couponRepository.findByCode(couponCode)
+                .orElseThrow(() -> new CustomException(404, "유효하지 않은 쿠폰 코드입니다."));
+
+        if (coupon.getExpDate().isBefore(LocalDate.now())) {
+            throw new CustomException(404, "만료된 쿠폰입니다.");
+        }
+
+        ClientCoupon clientCoupon = ClientCoupon.builder()
+                .client(client)
+                .coupon(coupon)
+                .isUsed(false)
+                .build();
+
+        return clientCouponRepository.save(clientCoupon).getId();
     }
 
 }

--- a/src/main/java/com/erp/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/erp/domain/coupon/service/CouponService.java
@@ -1,0 +1,55 @@
+package com.erp.domain.coupon.service;
+
+import com.erp.domain.client.entity.Client;
+import com.erp.domain.client.repository.ClientRepository;
+import com.erp.domain.coupon.dto.request.CouponSaveRequest;
+import com.erp.domain.coupon.entity.ClientCoupon;
+import com.erp.domain.coupon.entity.Coupon;
+import com.erp.domain.coupon.repository.ClientCouponRepository;
+import com.erp.domain.coupon.repository.CouponRepository;
+import com.erp.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final ClientCouponRepository clientCouponRepository;
+    private final ClientRepository clientRepository;
+
+    /* [관리자] 쿠폰 생성 */
+    @Transactional
+    public Long createCoupon(CouponSaveRequest requestDto) {
+        String couponCode = requestDto.code();
+
+        if (couponCode == null || couponCode.isBlank()) {
+            couponCode = generateRandomCode();
+        } else {
+            if (couponRepository.findByCode(couponCode).isPresent()) {
+                throw new CustomException(404, "이미 존재하는 쿠폰 코드입니다.");
+            }
+        }
+
+        Coupon coupon = Coupon.builder()
+                .couponName(requestDto.couponName())
+                .discount(requestDto.discount())
+                .expDate(requestDto.expDate())
+                .code(couponCode)
+                .minPrice(requestDto.minPrice())
+                .build();
+
+        return couponRepository.save(coupon).getId();
+    }
+
+    private String generateRandomCode() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- 관리자용 쿠폰 생성, 사용자용 쿠폰 발급 및 내 쿠폰함 조회 기능을 구현했습니다.
- 쿠폰 생성 API : 관리자가 쿠폰 정책(할인액, 만료일 등)을 생성
- 쿠폰 발급 API : 사용자가 쿠폰 코드를 입력하여 쿠폰 발급
- 내 쿠폰 조회 API : 사용자가 보유한 쿠폰 목록과 상태(사용가능/만료/사용됨) 조회

## 부연설명
- 관리자가 쿠폰 코드를 별도로 입력하지 않을 경우, UUID 기반의 8자리 랜덤 코드가 자동으로 생성되도록 구현했습니다.
- 할인 금액보다 상품 금액이 적을 경우 결제 금액이 마이너스가 되는 논리적 오류를 방지하기 위해 minPrice(최소 주문 금액) 필드를 추가하였습니다.
- 현재 테스트 위해 임의로 1,000원으로 설정해 두었으며, 추후 기획이 확정되면 변경 가능합니다.
- 하나의 쿠폰 코드를 여러 명에게 발급하는 1:N 구조이므로 테이블을 분리했습니다.
   - Coupon : 할인액, 코드 등 공통 정책 관리
   - ClientCoupon : 사용자별 발급 및 사용 상태 관리

## 관련 이슈
-  #66 
