### PR TITLE
Feat: 차량 목록 번호판 검색 추가 및 조회 API 수정

### DIFF
--- a/src/main/java/com/erp/domain/car/dto/request/CarSearchRequest.java
+++ b/src/main/java/com/erp/domain/car/dto/request/CarSearchRequest.java
@@ -9,7 +9,8 @@ public record CarSearchRequest (
     String brand,
     String model,
     FuelType fuelType,
-    CarStatus status
+    CarStatus status,
+    String carNumber
 
 ) {
 }

--- a/src/main/java/com/erp/domain/car/dto/response/CarDetailResponse.java
+++ b/src/main/java/com/erp/domain/car/dto/response/CarDetailResponse.java
@@ -25,7 +25,8 @@ public record CarDetailResponse(
         Long purchasePrice,
         Long modelPrice,
         Integer seater,
-        String color
+        String color,
+        LocalDate createdAt
 
 ) {
 }

--- a/src/main/java/com/erp/domain/car/dto/response/CarStatusCountResponse.java
+++ b/src/main/java/com/erp/domain/car/dto/response/CarStatusCountResponse.java
@@ -5,9 +5,9 @@ import lombok.Builder;
 @Builder
 public record CarStatusCountResponse(
 
-        long total,
-        long driving,
-        long maintenance,
-        long waiting
+        Long total,
+        Long driving,
+        Long maintenance,
+        Long waiting
 ) {
 }

--- a/src/main/java/com/erp/domain/car/repository/CarRepository.java
+++ b/src/main/java/com/erp/domain/car/repository/CarRepository.java
@@ -45,6 +45,7 @@ public interface CarRepository extends JpaRepository<Car, Long> {
       AND (:model IS NULL OR c.model LIKE %:model%)
       AND (:fuelType IS NULL OR c.fuelType = :fuelType)
       AND (:status IS NULL OR c.status = :status)
+      AND (:carNumber IS NULL OR c.carNumber LIKE %:carNumber%)
     """)
     Page<Car> searchCars(
             @Param("branchId") Long branchId,
@@ -52,6 +53,7 @@ public interface CarRepository extends JpaRepository<Car, Long> {
             @Param("model") String model,
             @Param("fuelType") FuelType fuelType,
             @Param("status") CarStatus status,
+            @Param("carNumber") String carNumber,
             Pageable pageable);
 
     /* 차량 상태별 수량 조회 */

--- a/src/main/java/com/erp/domain/car/service/CarService.java
+++ b/src/main/java/com/erp/domain/car/service/CarService.java
@@ -288,6 +288,7 @@ public class CarService {
                 request.model(),
                 request.fuelType(),
                 request.status(),
+                request.carNumber(),
                 pageable
         );
 

--- a/src/main/java/com/erp/domain/car/service/CarService.java
+++ b/src/main/java/com/erp/domain/car/service/CarService.java
@@ -244,6 +244,7 @@ public class CarService {
                 .modelPrice(car.getModelPrice())
                 .seater(car.getSeater())
                 .color(car.getColor().name())
+                .createdAt(car.getCreatedAt().toLocalDate())
                 .build();
     }
 


### PR DESCRIPTION
## 작업 내용
이슈 #35에서 요청된 차량 조회 관련 기능 추가 및 API 수정 작업을 했습니다.
- 차량 목록 조회에서 번호판으로 차량을 검색할 수 있도록 기능 추가했습니다.
- 차량 상세 조회 응답에 누락되었던 시스템 등록일자 필드를 추가했습니다.
- 코드 일관성을 위해 CarStatusCountResponse의 필드 타입을 기본형 long -> 래퍼 클래스 Long으로 변경하였습니다.
## 부연설명
- 번호판은 전체 번호을 입력하지 않고 뒷자리 번호만 입력해도 검색이 되도록 하였습니다.
## 관련 이슈
-  #35
