### PR TITLE
Fix: 렌트 엔티티 변경에 따른 인기 차종 통계 로직 수정

### DIFF
--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -50,11 +50,11 @@ public class StatisticsController {
 
     /* 인기 차종(모델별) 대여 횟수 순위 조회 */
     // todo 인기 차종(모델별) 대여 횟수 통계
-//    @GetMapping("/car")
-//    public List<CarStatisticsResponse> getPopularCarModelStats(
-//            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
-//            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
-//    ) {
-//        return statisticsService.getPopularCarModelStats(startDate, endDate);
-//    }
+    @GetMapping("/car")
+    public List<CarStatisticsResponse> getPopularCarModelStats(
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        return statisticsService.getPopularCarModelStats(startDate, endDate);
+    }
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -70,22 +70,22 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
     );
 
     /* 인기 차종(모델별) 대여 횟수 통계 */
-    // todo 인기 차종(모델별) 대여 횟수 통계
-//    @Query(value = """
-//            SELECT
-//                r.brand AS brand,
-//                r.model AS model,
-//                COUNT(r.id) AS count
-//            FROM rent r
-//            WHERE r.end_rent_date_time IS NOT NULL
-//            AND r.start_rent_date_time BETWEEN :startDate AND :endDate
-//            GROUP BY r.brand, r.model
-//            ORDER BY count DESC
-//            """,
-//            nativeQuery = true)
-//    List<CarStatisticsProjection> findPopularCarModel(
-//            @Param("startDate") LocalDateTime startDate,
-//            @Param("endDate") LocalDateTime endDate
-//    );
+    @Query(value = """
+            SELECT
+                c.brand AS brand,
+                c.model AS model,
+                COUNT(r.id) AS count
+            FROM rent r
+            INNER JOIN car c ON r.car_id = c.id
+            WHERE r.start_rent_date_time BETWEEN :startDate AND :endDate
+              AND r.status != 'CANCELLED'
+            GROUP BY c.brand, c.model
+            ORDER BY count DESC
+            """,
+            nativeQuery = true)
+    List<CarStatisticsProjection> findPopularCarModel(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 
 }

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -77,23 +77,23 @@ public class StatisticsService {
     }
 
     /* 인기 차종(모델별) 대여 횟수 조회 */
-    // todo 인기 차종(모델별) 대여 횟수 통계
-//    public List<CarStatisticsResponse> getPopularCarModelStats(LocalDate start, LocalDate end) {
-//
-//        LocalDateTime startDate = start.atStartOfDay();
-//        LocalDateTime endDate = end.atTime(23, 59, 59);
-//
-//        if (startDate.isAfter(endDate)) {
-//            throw new CustomException(400, "시작 날짜는 종료 날짜보다 빨라야 합니다.");
-//        }
-//
-//        return statisticsRepository.findPopularCarModel(startDate, endDate)
-//                .stream()
-//                .map(row -> new CarStatisticsResponse(
-//                        row.getBrand(),
-//                        row.getModel(),
-//                        row.getCount()))
-//                .toList();
-//    }
+    public List<CarStatisticsResponse> getPopularCarModelStats(LocalDate start, LocalDate end) {
+
+        LocalDateTime startDate = start.atStartOfDay();
+        LocalDateTime endDate = end.atTime(23, 59, 59);
+
+        if (startDate.isAfter(endDate)) {
+            throw new CustomException(400, "시작 날짜는 종료 날짜보다 빨라야 합니다.");
+        }
+
+        return statisticsRepository.findPopularCarModel(startDate, endDate)
+                .stream()
+                .map(row -> new CarStatisticsResponse(
+                        row.getBrand(),
+                        row.getModel(),
+                        row.getCount()
+                ))
+                .toList();
+    }
 
 }


### PR DESCRIPTION
## 작업 내용
- Rent 엔티티 변경에 따른 인기 차종 통계 로직을 수정하였습니다.
- Rent 엔티티에서 차량 정보(brand,model)가 제거되고 Car 엔티티와 연관관계가 설정됨에 따라 INNER JOIN 로직을 추가하였습니다.
- 엔티티 변경 영향으로 빌드 에러 방지를 위해 임시 주석 처리했던 StatisticsService 및 StatisticsController 내 인기 차종 조회 로직 모두 복구했습니다.
## 부연설명
- StatisticsRepository 내 다른 통계 메서드들이 Native Query를 사용하고 있어, 일관성을 유지하고 복잡한 SQL 가독성을 높이기 위해 Native Query 방식을 채택했습니다.

## 관련 이슈
-  #76 
