### PR TITLE
Feat: 기간별 매출 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -49,7 +49,6 @@ public class StatisticsController {
     }
 
     /* 인기 차종(모델별) 대여 횟수 순위 조회 */
-    // todo 인기 차종(모델별) 대여 횟수 통계
     @GetMapping("/car")
     public List<CarStatisticsResponse> getPopularCarModelStats(
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
@@ -74,5 +73,14 @@ public class StatisticsController {
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
         return statisticsService.getWeeklySalesStats(startDate, endDate);
+    }
+
+    /* 일간 매출 통계 조회 */
+    @GetMapping("/sales/day")
+    public List<StatisticsResponse> getDailySalesStats(
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        return statisticsService.getDailySalesStats(startDate, endDate);
     }
 }

--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -57,4 +57,13 @@ public class StatisticsController {
     ) {
         return statisticsService.getPopularCarModelStats(startDate, endDate);
     }
+
+    /* 월간 매출 조회 */
+    @GetMapping("/sales/month")
+    public List<StatisticsResponse> getMonthlySalesStats(
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth startMonth,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth endMonth
+    ) {
+        return statisticsService.getMonthlySalesStats(startMonth, endMonth);
+    }
 }

--- a/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/erp/domain/statistics/controller/StatisticsController.java
@@ -58,12 +58,21 @@ public class StatisticsController {
         return statisticsService.getPopularCarModelStats(startDate, endDate);
     }
 
-    /* 월간 매출 조회 */
+    /* 월간 매출 통계 조회 */
     @GetMapping("/sales/month")
     public List<StatisticsResponse> getMonthlySalesStats(
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth startMonth,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth endMonth
     ) {
         return statisticsService.getMonthlySalesStats(startMonth, endMonth);
+    }
+
+    /* 주간 매출 통계 조회 */
+    @GetMapping("/sales/week")
+    public List<StatisticsResponse> getWeeklySalesStats(
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        return statisticsService.getWeeklySalesStats(startDate, endDate);
     }
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -118,6 +118,23 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
     """, nativeQuery = true)
     List<StatisticsProjection> findWeeklySales(
             @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
+    /* 일간 매출 통계 */
+    @Query(value = """
+    SELECT 
+        DATE_FORMAT(p.paid_at, '%Y-%m-%d') AS label,
+        SUM(p.amount) AS count
+    FROM payment p
+    WHERE p.paid_at BETWEEN :startDate AND :endDate
+      AND p.status = 'PAID'
+    GROUP BY label
+    ORDER BY label ASC
+    """, nativeQuery = true)
+    List<StatisticsProjection> findDailySales(
+            @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate);
+
 
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -105,4 +105,19 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             @Param("endDate") LocalDateTime endDate
     );
 
+    /* 주간 매출 통계 */
+    @Query(value = """
+    SELECT 
+        DATE_FORMAT(DATE_SUB(p.paid_at, INTERVAL (WEEKDAY(p.paid_at)) DAY), '%Y-%m-%d') AS label,
+        SUM(p.amount) AS count
+    FROM payment p
+    WHERE p.paid_at BETWEEN :startDate AND :endDate
+      AND p.status = 'PAID'
+    GROUP BY label
+    ORDER BY label ASC
+    """, nativeQuery = true)
+    List<StatisticsProjection> findWeeklySales(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
+
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -88,4 +88,21 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             @Param("endDate") LocalDateTime endDate
     );
 
+    /* 월간 매출 통계 */
+    @Query(value = """
+        SELECT 
+            DATE_FORMAT(p.paid_at, '%Y-%m') As label,
+            SUM(p.amount) AS count
+        FROM payment p
+        WHERE p.paid_at BETWEEN :startDate AND :endDate
+            AND p.status = 'PAID'
+        GROUP BY label
+        ORDER BY label ASC 
+    """,
+        nativeQuery = true)
+    List<StatisticsProjection> findMonthlySales(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
 }

--- a/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/erp/domain/statistics/repository/StatisticsRepository.java
@@ -13,8 +13,7 @@ import java.util.List;
 public interface StatisticsRepository extends JpaRepository<Rent, Long> {
 
     /* 월간 대여 건수 조회 */
-    @Query(
-            value = """
+    @Query(value = """
             SELECT
                 DATE_FORMAT(r.start_rent_date_time, '%Y-%m') AS label,
                 COUNT(r.id) AS count
@@ -24,16 +23,14 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             GROUP BY label
             ORDER BY label ASC
         """,
-            nativeQuery = true
-    )
+            nativeQuery = true)
     List<StatisticsProjection> findMonthlyRentCount(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
 
     /* 일간 대여 건수 조회 */
-    @Query(
-            value = """
+    @Query(value = """
             SELECT
                 DATE_FORMAT(r.start_rent_date_time, '%Y-%m-%d') AS label,
                 COUNT(r.id) AS count
@@ -43,16 +40,14 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             GROUP BY label
             ORDER BY label ASC
         """,
-            nativeQuery = true
-    )
+            nativeQuery = true)
     List<StatisticsProjection> findDailyRentCount(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
 
     /* 주간 대여 건수 조회 */
-    @Query(
-            value = """
+    @Query(value = """
             SELECT
                 DATE_FORMAT(r.start_rent_date_time, '%Y-%u') AS label,
                 COUNT(r.id) AS count
@@ -62,8 +57,7 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
             GROUP BY label
             ORDER BY label ASC
         """,
-            nativeQuery = true
-    )
+            nativeQuery = true)
     List<StatisticsProjection> findWeeklyRentCount(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
@@ -115,7 +109,8 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
       AND p.status = 'PAID'
     GROUP BY label
     ORDER BY label ASC
-    """, nativeQuery = true)
+    """,
+        nativeQuery = true)
     List<StatisticsProjection> findWeeklySales(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
@@ -131,7 +126,8 @@ public interface StatisticsRepository extends JpaRepository<Rent, Long> {
       AND p.status = 'PAID'
     GROUP BY label
     ORDER BY label ASC
-    """, nativeQuery = true)
+    """,
+        nativeQuery = true)
     List<StatisticsProjection> findDailySales(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate);

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -120,4 +120,16 @@ public class StatisticsService {
                 .toList();
     }
 
+    /* 일간 매출 통계 */
+    public List<StatisticsResponse> getDailySalesStats(LocalDate start, LocalDate end) {
+
+        LocalDateTime startDate = start.atStartOfDay();
+        LocalDateTime endDate = end.atTime(23, 59, 59);
+
+        return statisticsRepository.findDailySales(startDate, endDate)
+                .stream()
+                .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -96,4 +96,15 @@ public class StatisticsService {
                 .toList();
     }
 
+    /* 월간 매출 통계 */
+    public List<StatisticsResponse> getMonthlySalesStats(YearMonth start, YearMonth end) {
+        LocalDateTime startDate = start.atDay(1).atStartOfDay();
+        LocalDateTime endDate = end.atEndOfMonth().atTime(23, 59, 59);
+
+        return statisticsRepository.findMonthlySales(startDate, endDate)
+                .stream()
+                .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -98,10 +98,23 @@ public class StatisticsService {
 
     /* 월간 매출 통계 */
     public List<StatisticsResponse> getMonthlySalesStats(YearMonth start, YearMonth end) {
+
         LocalDateTime startDate = start.atDay(1).atStartOfDay();
         LocalDateTime endDate = end.atEndOfMonth().atTime(23, 59, 59);
 
         return statisticsRepository.findMonthlySales(startDate, endDate)
+                .stream()
+                .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
+                .toList();
+    }
+
+    /* 주간 매출 통계 */
+    public List<StatisticsResponse> getWeeklySalesStats(LocalDate start, LocalDate end) {
+
+        LocalDateTime startDate = start.atStartOfDay();
+        LocalDateTime endDate = end.atTime(23, 59, 59);
+
+        return statisticsRepository.findWeeklySales(startDate, endDate)
                 .stream()
                 .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
                 .toList();

--- a/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/erp/domain/statistics/service/StatisticsService.java
@@ -104,7 +104,9 @@ public class StatisticsService {
 
         return statisticsRepository.findMonthlySales(startDate, endDate)
                 .stream()
-                .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
+                .map(row -> new StatisticsResponse(
+                        row.getLabel(),
+                        row.getCount()))
                 .toList();
     }
 
@@ -116,7 +118,9 @@ public class StatisticsService {
 
         return statisticsRepository.findWeeklySales(startDate, endDate)
                 .stream()
-                .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
+                .map(row -> new StatisticsResponse(
+                        row.getLabel(),
+                        row.getCount()))
                 .toList();
     }
 
@@ -128,7 +132,9 @@ public class StatisticsService {
 
         return statisticsRepository.findDailySales(startDate, endDate)
                 .stream()
-                .map(row -> new StatisticsResponse(row.getLabel(), row.getCount()))
+                .map(row -> new StatisticsResponse(
+                        row.getLabel(),
+                        row.getCount()))
                 .toList();
     }
 


### PR DESCRIPTION
## 작업 내용
- 결제 데이터를 기반으로 관리자 페이지에서 사용할 기간별 매출 통계 API 구현
- 월간 / 주간 / 일간 매출 통계 조회
## 부연설명
- 기간별 대여 건수 조회와 인기 차종 통계와 동일하게 Native Query와 Projection을 사용하여 일관성을 유지했습니다.
## 관련 이슈
-  #72 
