### PR TITLE
Feat: 클라이언트 마이페이지 추가

### DIFF
--- a/src/main/java/com/erp/domain/client/controller/ClientController.java
+++ b/src/main/java/com/erp/domain/client/controller/ClientController.java
@@ -1,18 +1,16 @@
 package com.erp.domain.client.controller;
 
-import com.erp.domain.client.dto.request.EmailCheckRequestDto;
-import com.erp.domain.client.dto.request.LoginRequestDto;
-import com.erp.domain.client.dto.request.RegisterClientRequestDto;
+import com.erp.domain.client.dto.request.*;
+import com.erp.domain.client.dto.response.MypageResponse;
 import com.erp.domain.client.service.ClientService;
-import com.erp.global.jwt.JwtTokenProvider;
 import com.erp.global.jwt.TokenInfo;
+import com.sun.security.auth.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/client")
@@ -40,6 +38,34 @@ public class ClientController {
     public ResponseEntity<Void> registerClient(@Valid @RequestBody RegisterClientRequestDto requestDto) {
 
         clientService.registerClient(requestDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 내정보 조회
+    @PreAuthorize("hasAnyRole('CLIENT')")
+    @GetMapping("/mypage")
+    public ResponseEntity<MypageResponse> getMypage(
+            @AuthenticationPrincipal UserPrincipal user
+    ) {
+        return ResponseEntity.ok(clientService.getMypage(Long.parseLong(user.getName())));
+    }
+
+    @PreAuthorize("hasAnyRole('CLIENT')")
+    @PatchMapping("/mypage")
+    public ResponseEntity<Void> updateMypage(
+            @AuthenticationPrincipal UserPrincipal user,
+            MypageUpdateRequestDto dto
+    ) {
+        clientService.updateMypage(Long.parseLong(user.getName()), dto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasAnyRole('CLIENT')")
+    @PatchMapping("/password")
+    public ResponseEntity<Void> changePassword(
+            @AuthenticationPrincipal UserPrincipal user, ChangePasswordRequestDto dto
+    ) {
+        clientService.changePassword(Long.parseLong(user.getName()), dto);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/erp/domain/client/dto/request/ChangePasswordRequestDto.java
+++ b/src/main/java/com/erp/domain/client/dto/request/ChangePasswordRequestDto.java
@@ -1,0 +1,9 @@
+package com.erp.domain.client.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChangePasswordRequestDto(
+        @NotBlank(message = "비밀번호를 적어주세요 ")
+        String password
+) {
+}

--- a/src/main/java/com/erp/domain/client/dto/request/MypageUpdateRequestDto.java
+++ b/src/main/java/com/erp/domain/client/dto/request/MypageUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.erp.domain.client.dto.request;
+
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MypageUpdateRequestDto(
+
+        @Email(message = "이메일 형식이 아닙니다.")
+        String email,
+        LocalDate licenceDay
+) {
+
+}

--- a/src/main/java/com/erp/domain/client/dto/response/MypageResponse.java
+++ b/src/main/java/com/erp/domain/client/dto/response/MypageResponse.java
@@ -1,0 +1,18 @@
+package com.erp.domain.client.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MypageResponse(
+
+        String name,
+        String email,
+        String phoneNumber,
+        String licenceNumber,
+        String licenceArea,
+        LocalDate licenceDay
+) {
+
+}

--- a/src/main/java/com/erp/domain/client/service/ClientService.java
+++ b/src/main/java/com/erp/domain/client/service/ClientService.java
@@ -1,7 +1,10 @@
 package com.erp.domain.client.service;
 
+import com.erp.domain.client.dto.request.ChangePasswordRequestDto;
 import com.erp.domain.client.dto.request.LoginRequestDto;
+import com.erp.domain.client.dto.request.MypageUpdateRequestDto;
 import com.erp.domain.client.dto.request.RegisterClientRequestDto;
+import com.erp.domain.client.dto.response.MypageResponse;
 import com.erp.domain.client.entity.Client;
 import com.erp.domain.client.entity.Gender;
 import com.erp.domain.client.repository.ClientRepository;
@@ -118,5 +121,49 @@ public class ClientService {
             year += 2000;
         }
         return LocalDate.of(year, month, day);
+    }
+
+    public MypageResponse getMypage(Long userId) {
+        Client client = clientRepository.findById(userId).orElseThrow(
+                () -> new CustomException(404, "유저 정보가 정확하지 않습니다")
+        );
+
+
+        return MypageResponse.builder()
+                .email(client.getEmail())
+                .name(client.getName())
+                .phoneNumber(client.getPhoneNumber())
+                .licenceArea(client.getLicenceArea())
+                .licenceDay(client.getLicenceDay())
+                .licenceNumber(client.getLicenceNumber())
+                .build();
+    }
+
+    @Transactional
+    public void updateMypage(Long userId, MypageUpdateRequestDto dto) {
+        Client client = clientRepository.findById(userId).orElseThrow(
+                () -> new CustomException(404, "유저 정보가 정확하지 않습니다")
+        );
+
+        if (dto.email() != null) {
+
+            client.setEmail(dto.email());
+        }
+
+        if (dto.licenceDay() != null) {
+            client.setLicenceDay(dto.licenceDay());
+        }
+    }
+
+    public void changePassword(Long userId, ChangePasswordRequestDto dto) {
+        Client client = clientRepository.findById(userId).orElseThrow(
+                () -> new CustomException(404, "유저 정보가 정확하지 않습니다")
+        );
+
+        if (passwordEncoder.matches(dto.password(), client.getPassword())) {
+            throw new CustomException(400, "기존 비밀번호와 동일하게 변경할 수 없습니다.");
+        }
+
+        client.setPassword(passwordEncoder.encode(dto.password()));
     }
 }


### PR DESCRIPTION
## 작업 내용
- 클라이언트의 마이페이지 조회, 수정 기능을 추가합니다
- 비밀번호 변경은 API를 나누는것이 좋을것이라 판단되어 새로 만들어 API 명세서 수정 예정입니다.

## 부연설명
- 기존 로직에서 비밀번호 변경시(직원 비밀번호 변경) 동일 비밀번호로 변경 할 수 없는 정책을 발견하여 고객 비밀번호에도 해당 정책을 적용하려 했으나, 동시에 다른 정보를 받는 경우 사용자가 입력을 다시 받아야 하는 경우가 생겨 이를 방지하기 위해 비밀번호 변경 API를 분리했습니다.

## 관련 이슈
Close  #20 
