### PR TITLE
Feat: 관리자용 쿠폰 발급 유저 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/coupon/controller/ManagerCouponController.java
+++ b/src/main/java/com/erp/domain/coupon/controller/ManagerCouponController.java
@@ -2,6 +2,7 @@ package com.erp.domain.coupon.controller;
 
 import com.erp.domain.coupon.dto.request.CouponSaveRequest;
 import com.erp.domain.coupon.dto.response.AdminCouponResponse;
+import com.erp.domain.coupon.dto.response.IssuedClientCouponResponse;
 import com.erp.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,14 @@ public class ManagerCouponController {
             @PageableDefault(page = 0, size = 5, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return couponService.getAdminCoupons(pageable);
+    }
+
+    /* [관리자] 특정 쿠폰 발급 유저 목록 조회 */
+    @GetMapping("/{couponId}/clients")
+    public Page<IssuedClientCouponResponse> getIssuedClients(
+            @PathVariable Long couponId,
+            @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return couponService.getIssuedClients(couponId, pageable);
     }
 }

--- a/src/main/java/com/erp/domain/coupon/dto/response/IssuedClientCouponResponse.java
+++ b/src/main/java/com/erp/domain/coupon/dto/response/IssuedClientCouponResponse.java
@@ -1,0 +1,16 @@
+package com.erp.domain.coupon.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record IssuedClientCouponResponse(
+
+        String clientName,
+        String email,
+        String phoneNumber,
+        LocalDateTime issuedAt,
+        LocalDateTime usedAt,
+        boolean isUsed
+) {
+}

--- a/src/main/java/com/erp/domain/coupon/repository/ClientCouponRepository.java
+++ b/src/main/java/com/erp/domain/coupon/repository/ClientCouponRepository.java
@@ -1,6 +1,8 @@
 package com.erp.domain.coupon.repository;
 
 import com.erp.domain.coupon.entity.ClientCoupon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +26,7 @@ public interface ClientCouponRepository extends JpaRepository<ClientCoupon, Long
     @Modifying(clearAutomatically = true)
     @Query("UPDATE ClientCoupon c SET c.isUsed = true, c.usedAt = :usedAt WHERE c.id = :id AND c.isUsed = false")
     int updateStatusToUsed(@Param("id") Long id, @Param("usedAt") LocalDateTime usedAt);
+
+    /* 특정 쿠폰 발급 내역 조회 */
+    Page<ClientCoupon> findByCouponId(Long couponId, Pageable pageable);
 }

--- a/src/main/java/com/erp/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/erp/domain/coupon/service/CouponService.java
@@ -5,6 +5,7 @@ import com.erp.domain.client.repository.ClientRepository;
 import com.erp.domain.coupon.dto.request.CouponSaveRequest;
 import com.erp.domain.coupon.dto.response.AdminCouponResponse;
 import com.erp.domain.coupon.dto.response.ClientCouponResponse;
+import com.erp.domain.coupon.dto.response.IssuedClientCouponResponse;
 import com.erp.domain.coupon.entity.ClientCoupon;
 import com.erp.domain.coupon.entity.Coupon;
 import com.erp.domain.coupon.entity.CouponStatus;
@@ -95,6 +96,20 @@ public class CouponService {
                     status
             );
         });
+    }
+
+    /* [관리자] 특정 쿠폰 발급 유저 목록 조회 */
+    public Page<IssuedClientCouponResponse> getIssuedClients(Long couponId, Pageable pageable) {
+
+        return clientCouponRepository.findByCouponId(couponId, pageable)
+                .map(clientCoupon -> new IssuedClientCouponResponse(
+                        clientCoupon.getClient().getName(),
+                        clientCoupon.getClient().getEmail(),
+                        clientCoupon.getClient().getPhoneNumber(),
+                        clientCoupon.getCreatedAt(),
+                        clientCoupon.getUsedAt(),
+                        clientCoupon.isUsed()
+                ));
     }
 
     /* [사용자] 쿠폰 발급 */


### PR DESCRIPTION
## 작업 내용
- 관리자 페이지에서 특정 쿠폰을 발급받은 회원의 목록을 조회하는 API 구현
- 유저 기본 정보(이름, 이메일,전화번호), 발급일, 사용일, 쿠폰 사용 여부 포함
## 부연설명
- 페이징 처리(기본 10건)
## 관련 이슈
-  #92 
