### PR TITLE
Feat: 클라이언트 이벤트 배너용 쿠폰 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/erp/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/erp/domain/coupon/controller/CouponController.java
@@ -2,6 +2,7 @@ package com.erp.domain.coupon.controller;
 
 import com.erp.domain.coupon.dto.request.CouponIssueRequest;
 import com.erp.domain.coupon.dto.response.ClientCouponResponse;
+import com.erp.domain.coupon.dto.response.EventCouponResponse;
 import com.erp.domain.coupon.service.CouponService;
 import com.sun.security.auth.UserPrincipal;
 import jakarta.validation.Valid;
@@ -37,6 +38,12 @@ public class CouponController {
         Long clientId = Long.parseLong(user.getName());
 
         return couponService.getClientCoupons(clientId);
+    }
+
+    /* [사용자] 랜딩 페이지 이벤트 배너용 쿠폰 목록 */
+    @GetMapping("/event")
+    public List<EventCouponResponse> getEventCoupons() {
+        return couponService.getActiveCoupons();
     }
 
 }

--- a/src/main/java/com/erp/domain/coupon/dto/response/EventCouponResponse.java
+++ b/src/main/java/com/erp/domain/coupon/dto/response/EventCouponResponse.java
@@ -1,0 +1,15 @@
+package com.erp.domain.coupon.dto.response;
+
+import java.time.LocalDate;
+
+public record EventCouponResponse(
+
+        Long clientId,
+        String code,
+        String couponName,
+        Integer remainQuantity,
+        LocalDate startDate,
+        LocalDate endDate,
+        LocalDate expDate
+) {
+}

--- a/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/erp/domain/coupon/repository/CouponRepository.java
@@ -2,7 +2,10 @@ package com.erp.domain.coupon.repository;
 
 import com.erp.domain.coupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +16,15 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     /* 쿠폰 목록(최신순) 전체 조회 */
     List<Coupon> findAllByOrderByIdDesc();
+
+    /* 이벤트 배너용 쿠폰 목록 조회(오늘 날짜 기준으로 발급 가능한 쿠폰 목록)  */
+    @Query("""
+            SELECT c
+            FROM Coupon c
+            WHERE c.startDate <= :today
+            AND c.endDate >= :today
+            AND c.issuedQuantity < c.maxQuantity
+            ORDER BY c.id DESC
+            """)
+    List<Coupon> findActiveCoupons(@Param("today") LocalDate today);
 }

--- a/src/main/java/com/erp/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/erp/domain/coupon/service/CouponService.java
@@ -5,6 +5,7 @@ import com.erp.domain.client.repository.ClientRepository;
 import com.erp.domain.coupon.dto.request.CouponSaveRequest;
 import com.erp.domain.coupon.dto.response.AdminCouponResponse;
 import com.erp.domain.coupon.dto.response.ClientCouponResponse;
+import com.erp.domain.coupon.dto.response.EventCouponResponse;
 import com.erp.domain.coupon.dto.response.IssuedClientCouponResponse;
 import com.erp.domain.coupon.entity.ClientCoupon;
 import com.erp.domain.coupon.entity.Coupon;
@@ -173,6 +174,25 @@ public class CouponService {
                             status
                     );
                 })
+                .toList();
+    }
+
+    /* 이벤트 배너용 쿠폰 목록 조회 */
+    public List<EventCouponResponse> getActiveCoupons() {
+        LocalDate today = LocalDate.now();
+
+        List<Coupon> activeCoupons = couponRepository.findActiveCoupons(today);
+
+        return activeCoupons.stream()
+                .map(coupon -> new EventCouponResponse(
+                        coupon.getId(),
+                        coupon.getCode(),
+                        coupon.getCouponName(),
+                        coupon.getMaxQuantity() - coupon.getIssuedQuantity(),
+                        coupon.getStartDate(),
+                        coupon.getEndDate(),
+                        coupon.getExpDate()
+                ))
                 .toList();
     }
 


### PR DESCRIPTION
## 작업 내용
- 랜딩 페이지의 이벤트 배너에 노출할 현재 발급 가능한 쿠폰 목록을 조회하는 API 구현
- 쿠폰ID,  쿠폰코드, 쿠폰명, 남은수량, 시작일, 만료일, 사용기한
## 부연설명
- 잔여 수량이 남아있는 쿠폰만 조회되도록 하였습니다.
## 관련 이슈
-  #112 
