### PR TITLE
Refactor: 재결제 시나리오를 고려한 WAITING_PAYMENT 상태를 로직에서 제외

### DIFF
--- a/src/main/java/com/erp/domain/rent/repository/RentRepository.java
+++ b/src/main/java/com/erp/domain/rent/repository/RentRepository.java
@@ -145,12 +145,12 @@ public interface RentRepository extends JpaRepository<Rent, Long> {
             Pageable pageable
     );
 
-    // 고객의 활성화된 예약(결제 대기 또는 예약 확정) 존재 여부 확인
+    // 고객의 확정된 예약 존재 여부 확인
     @Query("""
             SELECT COUNT(r) > 0
             FROM Rent r
             WHERE r.client.id = :clientId
-            AND r.status IN (com.erp.domain.rent.entity.RentStatus.WAITING_PAYMENT, com.erp.domain.rent.entity.RentStatus.RESERVED)
+            AND r.status = com.erp.domain.rent.entity.RentStatus.RESERVED
             """)
     boolean existsActiveRentByClientId(@Param("clientId") Long clientId);
 }

--- a/src/main/java/com/erp/domain/rent/repository/RentRepository.java
+++ b/src/main/java/com/erp/domain/rent/repository/RentRepository.java
@@ -9,8 +9,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -70,21 +72,14 @@ public interface RentRepository extends JpaRepository<Rent, Long> {
                                   @Param("startDateTime") LocalDateTime startDateTime,
                                   @Param("endDateTime") LocalDateTime endDateTime);
 
-    // 내 결제 대기 내역 조회 (시간 겹침 확인)
+    @Modifying
+    @Transactional
     @Query("""
-            SELECT r FROM Rent r
-            WHERE r.car.id = :carId
-            AND r.client.id = :clientId
-            AND r.status = com.erp.domain.rent.entity.RentStatus.WAITING_PAYMENT
-            AND r.startRentDateTime < :endDateTime
-            AND r.endRentDateTime > :startDateTime
+                DELETE FROM Rent r
+                WHERE r.client.id = :clientId
+                AND r.status = com.erp.domain.rent.entity.RentStatus.WAITING_PAYMENT
             """)
-    List<Rent> findMyWaitingRents(
-            @Param("carId") Long carId,
-            @Param("clientId") Long clientId,
-            @Param("startDateTime") LocalDateTime startDateTime,
-            @Param("endDateTime") LocalDateTime endDateTime
-    );
+    void deleteAllWaitingRentsByClientId(@Param("clientId") Long clientId);
 
     // 비관적 락을 사용하여 예약을 조회
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/erp/domain/rent/service/RentService.java
+++ b/src/main/java/com/erp/domain/rent/service/RentService.java
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -81,18 +80,8 @@ public class RentService {
             throw new CustomException(400, "대여 기간은 최대 14일을 초과할 수 없습니다.");
         }
 
-        // 내 기존 결제 대기 내역(WAITING_PAYMENT)이 있다면 삭제 (재결제 시도 허용)
-        List<Rent> myWaitingRents = rentRepository.findMyWaitingRents(
-                request.carId(),
-                client.getId(),
-                request.startRentDateTime(),
-                request.endRentDateTime()
-        );
-
-        if (!myWaitingRents.isEmpty()) {
-            rentRepository.deleteAll(myWaitingRents);
-            rentRepository.flush(); // 즉시 삭제 반영
-        }
+        rentRepository.deleteAllWaitingRentsByClientId(userId);
+        rentRepository.flush();
 
         // 해당 기간에 이미 예약이 있는지 확인. 1차 검증
         boolean isOverlapped = rentRepository.existsOverlappingRent(

--- a/src/main/java/com/erp/domain/rent/service/RentService.java
+++ b/src/main/java/com/erp/domain/rent/service/RentService.java
@@ -56,9 +56,9 @@ public class RentService {
 
     @Transactional
     public RentCreateResponse createRent(RentCreateRequest request, Long userId) {
-        // 고객의 기존 활성 예약 여부 검증
+        // 고객의 기존 예약 여부 검증
         if (rentRepository.existsActiveRentByClientId(userId)) {
-            throw new CustomException(400, "이미 진행 중이거나 예약된 대여가 존재합니다. 1인당 1건의 예약만 가능합니다.");
+            throw new CustomException(400, "이미 확정된 예약 내역이 존재합니다. 1인당 1건의 예약만 가능합니다.");
         }
 
         // 차량 및 고객 조회


### PR DESCRIPTION
## 작업 내용
- 재결제 시나리오를 고려한 WAITING_PAYMENT 상태를 로직에서 제외
## 부연설명
- 결제 도중 이탈하거나 실패한 '결제 대기(WAITING_PAYMENT)' 데이터의 자동 정리 로직이 있기 때문